### PR TITLE
Add basic conversation persistence and agent scheduler

### DIFF
--- a/app/api/cloud/[trpc]/route.ts
+++ b/app/api/cloud/[trpc]/route.ts
@@ -2,6 +2,12 @@ import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 
 import { appRouterCloud } from '~/server/trpc/trpc.router-cloud';
 import { createTRPCFetchContext } from '~/server/trpc/trpc.server';
+import { registerLocalAgiAgents } from '~/server/agents/localAgiAgent';
+import { globalAgentScheduler } from '~/server/agents/agentScheduler';
+
+// initialize agents
+registerLocalAgiAgents();
+globalAgentScheduler.start();
 
 const handlerNodeRoutes = (req: Request) => fetchRequestHandler({
   endpoint: '/api/cloud',

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "mammoth": "^1.9.1",
         "nanoid": "^5.1.5",
         "next": "~15.1.8",
+        "node-cron": "^3.0.3",
         "nprogress": "^0.2.0",
         "pdfjs-dist": "5.3.31",
         "posthog-js": "^1.249.1",
@@ -7761,6 +7762,18 @@
         }
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -10112,6 +10125,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mammoth": "^1.9.1",
     "nanoid": "^5.1.5",
     "next": "~15.1.8",
+    "node-cron": "^3.0.3",
     "nprogress": "^0.2.0",
     "pdfjs-dist": "5.3.31",
     "posthog-js": "^1.249.1",

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+import { AppHistory } from '../src/apps/history/AppHistory';
+import { withNextJSPerPageLayout } from '~/common/layout/withLayout';
+
+export default withNextJSPerPageLayout({ type: 'optima' }, () => <AppHistory />);

--- a/src/apps/history/AppHistory.tsx
+++ b/src/apps/history/AppHistory.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { apiQuery } from '~/common/util/trpc.client';
+import { Box, Button, List, ListItem, Typography } from '@mui/joy';
+
+export function AppHistory() {
+  const { data } = apiQuery.history.listConversations.useQuery({});
+  const [selected, setSelected] = React.useState<string | null>(null);
+  const convo = apiQuery.history.getConversation.useQuery({ conversationId: selected! }, { enabled: !!selected });
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography level='h2'>Conversations</Typography>
+      <List sx={{ maxWidth: 300 }}>
+        {data?.conversations.map(c => (
+          <ListItem key={c.id}>
+            <Button variant='plain' onClick={() => setSelected(c.id)}>{c.id}</Button>
+          </ListItem>
+        ))}
+      </List>
+      {convo.data && (
+        <Box>
+          <Typography level='h3'>Messages</Typography>
+          <List>
+            {convo.data.messages.map((m, idx) => (
+              <ListItem key={idx}>{m.role}: {m.content}</ListItem>
+            ))}
+          </List>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/modules/history/server/history.router.ts
+++ b/src/modules/history/server/history.router.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { createTRPCRouter, publicProcedure } from '~/server/trpc/trpc.server';
+import { prismaDb } from '~/server/prisma/prismaDb';
+
+const addMessageSchema = z.object({
+  conversationId: z.string().optional(),
+  sessionId: z.string().optional(),
+  role: z.string(),
+  content: z.string(),
+});
+
+const getConversationSchema = z.object({
+  conversationId: z.string(),
+});
+
+export const historyRouter = createTRPCRouter({
+  addMessage: publicProcedure
+    .input(addMessageSchema)
+    .output(z.object({ conversationId: z.string() }))
+    .mutation(async ({ input }) => {
+      const { conversationId, sessionId, role, content } = input;
+
+      let convId = conversationId;
+      if (!convId) {
+        const conversation = await prismaDb.conversation.create({
+          data: {
+            sessionId,
+          },
+        });
+        convId = conversation.id;
+      }
+
+      await prismaDb.message.create({
+        data: { conversationId: convId, role, content },
+      });
+
+      return { conversationId: convId };
+    }),
+
+  getConversation: publicProcedure
+    .input(getConversationSchema)
+    .output(z.object({ messages: z.array(z.object({ role: z.string(), content: z.string(), createdAt: z.date() })) }))
+    .query(async ({ input }) => {
+      const { conversationId } = input;
+      const messages = await prismaDb.message.findMany({
+        where: { conversationId },
+        orderBy: { createdAt: 'asc' },
+        select: { role: true, content: true, createdAt: true },
+      });
+      return { messages };
+    }),
+
+  listConversations: publicProcedure
+    .input(z.object({ sessionId: z.string().optional() }))
+    .output(z.object({ conversations: z.array(z.object({ id: z.string(), createdAt: z.date() })) }))
+    .query(async ({ input }) => {
+      const conversations = await prismaDb.conversation.findMany({
+        where: { sessionId: input.sessionId ?? undefined },
+        orderBy: { createdAt: 'desc' },
+        select: { id: true, createdAt: true },
+      });
+      return { conversations };
+    }),
+});

--- a/src/server/agents/agentScheduler.ts
+++ b/src/server/agents/agentScheduler.ts
@@ -1,0 +1,25 @@
+import cron from 'node-cron';
+
+export type AgentTask = () => Promise<void> | void;
+
+export class AgentScheduler {
+  private tasks: { cron: string; task: AgentTask }[] = [];
+
+  register(cronExpression: string, task: AgentTask) {
+    this.tasks.push({ cron: cronExpression, task });
+  }
+
+  start() {
+    for (const { cron: expr, task } of this.tasks) {
+      cron.schedule(expr, () => {
+        try {
+          Promise.resolve(task());
+        } catch (err) {
+          console.error('Agent task failed', err);
+        }
+      });
+    }
+  }
+}
+
+export const globalAgentScheduler = new AgentScheduler();

--- a/src/server/agents/localAgiAgent.ts
+++ b/src/server/agents/localAgiAgent.ts
@@ -1,0 +1,12 @@
+import { globalAgentScheduler } from './agentScheduler';
+
+// Placeholder for LocalAGI integration
+async function callLocalAGI(action: string) {
+  // In a real implementation this would call the LocalAGI service
+  console.log(`[LocalAGI] Executing action: ${action}`);
+}
+
+export function registerLocalAgiAgents() {
+  // Example: run every hour
+  globalAgentScheduler.register('0 * * * *', () => callLocalAGI('hourlyTask'));
+}

--- a/src/server/prisma/schema.prisma
+++ b/src/server/prisma/schema.prisma
@@ -61,3 +61,31 @@ enum LinkStorageVisibility {
 enum LinkStorageDataType {
   CHAT_V1
 }
+
+//
+// Persistent Chat History
+//
+
+model Conversation {
+  id String @id @default(uuid())
+
+  /** Optional session identifier to scope conversations */
+  sessionId String?
+
+  messages Message[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Message {
+  id String @id @default(uuid())
+
+  conversation   Conversation @relation(fields: [conversationId], references: [id])
+  conversationId String
+
+  role    String
+  content String
+
+  createdAt DateTime @default(now())
+}

--- a/src/server/trpc/trpc.router-cloud.ts
+++ b/src/server/trpc/trpc.router-cloud.ts
@@ -2,6 +2,7 @@ import { createTRPCRouter } from './trpc.server';
 
 import { browseRouter } from '~/modules/browse/browse.router';
 import { tradeRouter } from '~/modules/trade/server/trade.router';
+import { historyRouter } from '~/modules/history/server/history.router';
 
 /**
  * Cloud rooter, which is geolocated in 1 location and separate from the other routers.
@@ -10,6 +11,7 @@ import { tradeRouter } from '~/modules/trade/server/trade.router';
 export const appRouterCloud = createTRPCRouter({
   browse: browseRouter,
   trade: tradeRouter,
+  history: historyRouter,
 });
 
 // export type definition of API


### PR DESCRIPTION
## Summary
- create Conversation and Message models in Prisma schema
- implement `historyRouter` for basic conversation CRUD
- expose new router in the cloud API
- bootstrap agent scheduler and stub LocalAGI integration
- initialize scheduler in the cloud tRPC route
- add simple History page and UI component
- add `node-cron` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install --package-lock-only` *(fails to fetch Prisma engine)*


------
https://chatgpt.com/codex/tasks/task_e_6840793219d8832e9b8041f343348f95