### PR TITLE
Add landing page and move chat to /chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Note: After the V2 Q1 2025 release, `v2-dev` will become the default branch and 
 
 ### Quick links: 👉 [roadmap](https://github.com/users/enricoros/projects/4/views/2) 👉 [installation](docs/installation.md) 👉 [documentation](docs/README.md)
 
+### Landing page
+
+The root URL now presents a small landing page with links to common destinations. The chat application has moved to `/chat`.
+
 ---
 
 ### 5,000 Commits Milestone · Jan 2025

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+import { AppChat } from '../src/apps/chat/AppChat';
+
+import { withNextJSPerPageLayout } from '~/common/layout/withLayout';
+
+export default withNextJSPerPageLayout({ type: 'optima' }, () => <AppChat />);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 
-import { AppChat } from '../src/apps/chat/AppChat';
+import { AppLanding } from '../src/apps/landing/AppLanding';
 
 import { withNextJSPerPageLayout } from '~/common/layout/withLayout';
 
 
 export default withNextJSPerPageLayout({ type: 'optima' }, () => {
 
-  // TODO: This Index page will point to the Dashboard (or a landing page)
-  // For now it offers the chat experience, but this will change. #299
+  // Landing page with quick links to apps
 
-  return <AppChat />;
+  return <AppLanding />;
 });

--- a/src/apps/landing/AppLanding.tsx
+++ b/src/apps/landing/AppLanding.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import { Box, Button } from '@mui/joy';
+
+import { Brand } from '~/common/app.config';
+import { AppSmallContainer } from '../AppSmallContainer';
+import { launchAppChat, navigateToNews } from '~/common/app.routes';
+
+
+export function AppLanding() {
+  return (
+    <AppSmallContainer
+      title={`Welcome to ${Brand.Title.Common}`}
+      description='Select one of the tools below to get started.'
+    >
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <Button variant='solid' onClick={() => launchAppChat()}>
+          Open Chat
+        </Button>
+        <Button variant='soft' onClick={() => navigateToNews()}>
+          View News
+        </Button>
+      </Box>
+    </AppSmallContainer>
+  );
+}

--- a/src/common/app.routes.ts
+++ b/src/common/app.routes.ts
@@ -16,7 +16,7 @@ import { isBrowser } from './util/pwaUtils';
 
 
 export const ROUTE_INDEX = '/';
-export const ROUTE_APP_CHAT = '/';
+export const ROUTE_APP_CHAT = '/chat';
 export const ROUTE_APP_CALL = '/call';
 export const ROUTE_APP_LINK_CHAT = '/link/chat/[chatLinkId]';
 export const ROUTE_APP_NEWS = '/news';


### PR DESCRIPTION
## Summary
- add new landing page with links to Chat and News
- move Chat app to `/chat` path and update routes
- document landing page in README

## Testing
- `npm install` *(fails: Failed to fetch sha256 checksum)*

------
https://chatgpt.com/codex/tasks/task_e_6841b49b7050832ebad9e2b405c18822